### PR TITLE
Transform website to product studio hub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-vercel-ci-template",
+  "name": "toolz-studio",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/blog/building-sidethreadgpt/page.tsx
+++ b/src/app/blog/building-sidethreadgpt/page.tsx
@@ -1,0 +1,150 @@
+import Navigation from '@/components/Navigation';
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Link,
+  Separator,
+  Text,
+} from '@radix-ui/themes';
+import NextLink from 'next/link';
+
+export default function BuildingSideThreadGPT() {
+  return (
+    <Box
+      style={{
+        minHeight: '100vh',
+        background:
+          'radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.2), transparent 55%), radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.18), transparent 60%), #09090b',
+      }}
+    >
+      <Navigation />
+      <main>
+        <article>
+          <Flex
+            direction="column"
+            align="center"
+            gap="6"
+            style={{ maxWidth: '700px', margin: '0 auto', padding: '96px 24px 64px' }}
+          >
+            {/* Article Header */}
+            <Flex direction="column" gap="4" align="center" style={{ textAlign: 'center' }}>
+              <Button size="1" variant="soft" asChild>
+                <NextLink href="/blog">← Back to Blog</NextLink>
+              </Button>
+              
+              <Badge variant="soft">
+                Product Development
+              </Badge>
+              
+              <Heading size="8" weight="bold">
+                Building SideThreadGPT: Bringing AI to Your Browser
+              </Heading>
+              
+              <Flex gap="3" align="center">
+                <Text size="2" color="gray">March 15, 2024</Text>
+                <Text size="2" color="gray">•</Text>
+                <Text size="2" color="gray">5 min read</Text>
+              </Flex>
+            </Flex>
+
+            <Separator orientation="horizontal" size="4" />
+
+            {/* Article Content */}
+            <Flex direction="column" gap="6" style={{ width: '100%' }}>
+              <Text size="4" style={{ lineHeight: '1.6' }}>
+                When we started Toolz Studio, our mission was clear: create tools that genuinely enhance productivity without adding complexity to daily workflows. SideThreadGPT, our first Chrome extension, embodies this philosophy perfectly.
+              </Text>
+
+              <Heading size="5" weight="bold">
+                The Problem We Saw
+              </Heading>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                We noticed that while AI tools like ChatGPT were incredibly powerful, using them required constant context switching. You'd be reading an article, encounter something complex, then have to open a new tab, navigate to ChatGPT, copy and paste content, and lose your flow entirely.
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                This friction was killing productivity rather than enhancing it. We knew there had to be a better way.
+              </Text>
+
+              <Heading size="5" weight="bold">
+                Our Approach
+              </Heading>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                The solution seemed obvious in hindsight: bring the AI directly to where you're already working. Instead of forcing users to leave their current context, we built SideThreadGPT to work seamlessly within any web page.
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                But building a Chrome extension that works reliably across millions of websites presented unique challenges:
+              </Text>
+
+              <Box pl="4">
+                <Text size="3" style={{ lineHeight: '1.6' }}>
+                  • <strong>Performance:</strong> The extension needed to be lightweight and fast, never slowing down the browsing experience.
+                </Text>
+                <Text size="3" style={{ lineHeight: '1.6' }}>
+                  • <strong>Compatibility:</strong> It had to work seamlessly across different websites with varying layouts and technologies.
+                </Text>
+                <Text size="3" style={{ lineHeight: '1.6' }}>
+                  • <strong>Privacy:</strong> Users needed to trust that their browsing data remained private and secure.
+                </Text>
+                <Text size="3" style={{ lineHeight: '1.6' }}>
+                  • <strong>User Experience:</strong> The interface had to be intuitive enough that users could access AI help without learning new workflows.
+                </Text>
+              </Box>
+
+              <Heading size="5" weight="bold">
+                Key Features We Built
+              </Heading>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                After months of development and testing, we launched SideThreadGPT with several core features that address real user needs:
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                <strong>Text Selection AI:</strong> Simply select any text on a webpage to get instant AI assistance - whether you need a summary, explanation, or translation.
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                <strong>Context-Aware Responses:</strong> The AI understands the webpage you're viewing and provides relevant, contextual assistance.
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                <strong>Quick Access Panel:</strong> A floating panel that stays out of your way until you need it, then provides instant access to AI capabilities.
+              </Text>
+
+              <Heading size="5" weight="bold">
+                What's Next
+              </Heading>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                SideThreadGPT is just the beginning. We're already working on additional productivity tools that follow the same philosophy: powerful functionality that integrates seamlessly into existing workflows.
+              </Text>
+
+              <Text size="3" style={{ lineHeight: '1.6' }}>
+                Our upcoming tools will include a web-based productivity app, a mobile task manager, and additional browser extensions - all designed with the same attention to user experience and workflow integration.
+              </Text>
+
+              <Separator orientation="horizontal" size="4" />
+
+              <Flex direction="column" gap="4" align="center" style={{ textAlign: 'center' }}>
+                <Text size="3" color="gray">
+                  Ready to try SideThreadGPT for yourself?
+                </Text>
+                <Button size="3" asChild>
+                  <Link href="/products/sidethreadgpt">
+                    Learn More & Install
+                  </Link>
+                </Button>
+              </Flex>
+            </Flex>
+          </Flex>
+        </article>
+      </main>
+    </Box>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,138 @@
+import Navigation from '@/components/Navigation';
+import {
+  Badge,
+  Box,
+  Card,
+  Flex,
+  Heading,
+  Link,
+  Text,
+} from '@radix-ui/themes';
+import NextLink from 'next/link';
+
+interface BlogPost {
+  id: string;
+  title: string;
+  excerpt: string;
+  date: string;
+  readTime: string;
+  category: string;
+}
+
+const blogPosts: BlogPost[] = [
+  {
+    id: 'building-sidethreadgpt',
+    title: 'Building SideThreadGPT: Bringing AI to Your Browser',
+    excerpt: 'Learn about the journey of creating our first Chrome extension and the challenges we overcame to bring AI assistance directly to your browsing experience.',
+    date: 'March 15, 2024',
+    readTime: '5 min read',
+    category: 'Product Development',
+  },
+  {
+    id: 'productivity-workflows',
+    title: 'The Science of Productive Workflows',
+    excerpt: 'Discover the research-backed principles we use to design tools that genuinely enhance productivity without adding complexity to your daily routine.',
+    date: 'March 8, 2024',
+    readTime: '7 min read',
+    category: 'Productivity',
+  },
+  {
+    id: 'browser-extensions-future',
+    title: 'The Future of Browser Extensions in the AI Era',
+    excerpt: 'Exploring how AI is transforming browser extensions and what this means for the future of web-based productivity tools.',
+    date: 'February 28, 2024',
+    readTime: '6 min read',
+    category: 'Technology',
+  },
+  {
+    id: 'design-principles',
+    title: 'Our Design Principles: Simplicity Meets Power',
+    excerpt: 'A deep dive into the design philosophy that guides every product we create at Toolz Studio, focusing on intuitive interfaces and powerful functionality.',
+    date: 'February 20, 2024',
+    readTime: '4 min read',
+    category: 'Design',
+  },
+];
+
+export default function Blog() {
+  return (
+    <Box
+      style={{
+        minHeight: '100vh',
+        background:
+          'radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.2), transparent 55%), radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.18), transparent 60%), #09090b',
+      }}
+    >
+      <Navigation />
+      <main>
+        <Flex
+          direction="column"
+          align="center"
+          gap="8"
+          style={{ maxWidth: '800px', margin: '0 auto', padding: '96px 24px', textAlign: 'center' }}
+        >
+          <Flex direction="column" gap="4" align="center">
+            <Badge color="indigo" variant="surface">
+              Insights & Updates
+            </Badge>
+            <Heading size="8" weight="bold">
+              Blog
+            </Heading>
+            <Text size="4" color="gray" style={{ maxWidth: '600px' }}>
+              Thoughts on productivity, technology, and the tools that shape our digital workflows.
+            </Text>
+          </Flex>
+
+          <Flex direction="column" gap="6" style={{ width: '100%' }}>
+            {blogPosts.map((post) => (
+              <Card
+                key={post.id}
+                size="3"
+                variant="surface"
+                style={{
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                  background: 'linear-gradient(135deg, rgba(129, 140, 248, 0.05), transparent 60%), rgba(15, 23, 42, 0.85)',
+                }}
+              >
+                <Link asChild style={{ textDecoration: 'none', color: 'inherit' }}>
+                  <NextLink href={`/blog/${post.id}`}>
+                    <Flex direction="column" gap="4" align="start">
+                      <Flex justify="between" align="start" width="100%">
+                        <Badge variant="soft" size="1">
+                          {post.category}
+                        </Badge>
+                        <Flex gap="3" align="center">
+                          <Text size="1" color="gray">{post.date}</Text>
+                          <Text size="1" color="gray">•</Text>
+                          <Text size="1" color="gray">{post.readTime}</Text>
+                        </Flex>
+                      </Flex>
+
+                      <Flex direction="column" gap="2" align="start">
+                        <Heading as="h2" size="5" weight="bold">
+                          {post.title}
+                        </Heading>
+                        <Text size="3" color="gray" style={{ lineHeight: '1.5' }}>
+                          {post.excerpt}
+                        </Text>
+                      </Flex>
+
+                      <Text size="2" color="indigo" weight="medium">
+                        Read more →
+                      </Text>
+                    </Flex>
+                  </NextLink>
+                </Link>
+              </Card>
+            ))}
+          </Flex>
+
+          <Text size="3" color="gray" mt="6">
+            More articles coming soon. Follow our journey as we build the future of productivity tools.
+          </Text>
+        </Flex>
+      </main>
+    </Box>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import '@radix-ui/themes/styles.css';
 import { Theme } from '@radix-ui/themes';
 
 export const metadata: Metadata = {
-  title: 'Next.js Vercel Template',
-  description: 'Minimal template with Vercel CI/CD',
+  title: 'Toolz - Productive tools for your flow',
+  description: 'A product studio showcasing productive tools including extensions, mobile & web apps',
   icons: { icon: '/favicon.svg' },
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,110 +1,86 @@
-import Hello from '@/components/Hello';
+import Hero from '@/components/Hello';
+import Navigation from '@/components/Navigation';
+import ProductsShowcase from '@/components/ProductsShowcase';
 import {
   Badge,
   Box,
   Button,
-  Card,
   Flex,
   Heading,
   Link,
   Separator,
   Text,
 } from '@radix-ui/themes';
-import NextLink from 'next/link';
 
 export default function Home() {
-  const env = process.env.NEXT_PUBLIC_ENV ?? 'preview';
-  const features = [
-    {
-      title: 'Radix Themes',
-      description: 'Preconfigured design system with accessible building blocks and consistent styling.',
-    },
-    {
-      title: 'CI-ready',
-      description: 'Linting and type-check scripts wired for Vercel deployments out of the box.',
-    },
-    {
-      title: 'API health route',
-      description: 'Monitor deployments quickly with a built-in health check endpoint.',
-    },
-  ];
-
   return (
     <Box
-      asChild
       style={{
         minHeight: '100vh',
         background:
           'radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.2), transparent 55%), radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.18), transparent 60%), #09090b',
       }}
     >
+      <Navigation />
       <main>
+        {/* Hero Section */}
         <Flex
           direction="column"
           align="center"
           gap="6"
-          style={{ maxWidth: '960px', margin: '0 auto', padding: '96px 24px', textAlign: 'center' }}
+          style={{ maxWidth: '1200px', margin: '0 auto', padding: '96px 24px 64px', textAlign: 'center' }}
         >
-          <Badge color="jade" variant="surface">
-            Now shipping with Radix Themes
+          <Badge color="indigo" variant="surface">
+            Product Studio
           </Badge>
-          <Hello />
-          <Text size="4" color="gray">
-            Opinionated Next.js starter wired for Vercel — lean tooling, health checks, and a modern UI kit.
+          <Hero />
+          <Text size="5" color="gray" style={{ maxWidth: '600px' }}>
+            We build productive tools that seamlessly integrate into your workflow, helping you achieve more with less effort.
           </Text>
 
-          <Flex gap="4" wrap="wrap" justify="center">
+          <Flex gap="4" wrap="wrap" justify="center" mt="4">
             <Button size="3" asChild>
-              <NextLink href="/api/health">Check API Health</NextLink>
+              <Link href="#products">Explore Products</Link>
             </Button>
             <Button size="3" variant="soft" asChild>
-              <Link href="https://nextjs.org/docs" target="_blank" rel="noreferrer">
-                Next.js Docs
-              </Link>
+              <Link href="/blog">Read Our Blog</Link>
             </Button>
           </Flex>
+        </Flex>
 
-          <Card
-            variant="surface"
-            size="4"
-            style={{
-              width: '100%',
-              maxWidth: '520px',
-              background:
-                'linear-gradient(135deg, rgba(14, 165, 233, 0.18), transparent 60%), rgba(15, 23, 42, 0.85)',
-            }}
-          >
-            <Flex direction="column" gap="3" align="center">
-              <Badge color="blue" variant="soft">
-                Active Environment
-              </Badge>
-              <Heading size="6" weight="bold">
-                {env.toUpperCase()}
-              </Heading>
-              <Text size="2" color="gray">
-                Tailor your deployment previews with <code>NEXT_PUBLIC_ENV</code>.
-              </Text>
-              <Separator orientation="horizontal" size="4" my="1" />
-              <Text size="2" color="gray">
-                Deploy to Vercel and your environment will surface right here.
-              </Text>
-            </Flex>
-          </Card>
+        <Separator orientation="horizontal" size="4" />
 
-          <Flex gap="4" wrap="wrap" justify="center">
-            {features.map((feature) => (
-              <Card key={feature.title} size="3" variant="classic" style={{ width: '260px' }}>
-                <Flex direction="column" gap="2" align="start">
-                  <Heading as="h3" size="4">
-                    {feature.title}
-                  </Heading>
-                  <Text size="2" color="gray" align="left">
-                    {feature.description}
-                  </Text>
-                </Flex>
-              </Card>
-            ))}
-          </Flex>
+        {/* Products Section */}
+        <Flex
+          id="products"
+          direction="column"
+          align="center"
+          gap="8"
+          style={{ maxWidth: '1200px', margin: '0 auto', padding: '80px 24px' }}
+        >
+          <ProductsShowcase />
+        </Flex>
+
+        <Separator orientation="horizontal" size="4" />
+
+        {/* About Section */}
+        <Flex
+          direction="column"
+          align="center"
+          gap="6"
+          style={{ maxWidth: '800px', margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}
+        >
+          <Heading size="6" weight="bold">
+            About Toolz Studio
+          </Heading>
+          <Text size="4" color="gray" style={{ lineHeight: '1.6' }}>
+            We're passionate about creating tools that enhance productivity and streamline workflows. 
+            Our team focuses on building intuitive, powerful solutions that integrate seamlessly into your daily routine, 
+            whether you're browsing the web, managing tasks, or developing code.
+          </Text>
+          <Text size="3" color="gray">
+            More tools coming soon. Stay tuned for updates on our latest projects.
+          </Text>
         </Flex>
       </main>
     </Box>

--- a/src/app/products/sidethreadgpt/page.tsx
+++ b/src/app/products/sidethreadgpt/page.tsx
@@ -1,0 +1,226 @@
+import Navigation from '@/components/Navigation';
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Link,
+  Separator,
+  Text,
+} from '@radix-ui/themes';
+
+const features = [
+  {
+    title: 'Instant AI Assistance',
+    description: 'Get AI-powered help without leaving your current tab. Simply select text or use our quick access panel.',
+  },
+  {
+    title: 'Context-Aware Responses',
+    description: 'SideThreadGPT understands the content you\'re viewing and provides relevant, contextual assistance.',
+  },
+  {
+    title: 'Privacy-First Design',
+    description: 'Your browsing data stays private. We only process what you explicitly share with the AI.',
+  },
+  {
+    title: 'Seamless Integration',
+    description: 'Works on any website without disrupting your browsing experience. Lightweight and fast.',
+  },
+];
+
+const useCases = [
+  'Summarize long articles and research papers',
+  'Get explanations for complex technical concepts',
+  'Generate quick responses to emails and messages',
+  'Translate text in real-time while browsing',
+  'Get coding help and explanations for code snippets',
+  'Create outlines and notes from web content',
+];
+
+export default function SideThreadGPT() {
+  return (
+    <Box
+      style={{
+        minHeight: '100vh',
+        background:
+          'radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.2), transparent 55%), radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.18), transparent 60%), #09090b',
+      }}
+    >
+      <Navigation />
+      <main>
+        {/* Hero Section */}
+        <Flex
+          direction="column"
+          align="center"
+          gap="6"
+          style={{ maxWidth: '800px', margin: '0 auto', padding: '96px 24px 64px', textAlign: 'center' }}
+        >
+          <Badge color="green" variant="surface">
+            Chrome Extension • Available Now
+          </Badge>
+          <Heading size="9" weight="bold">
+            SideThreadGPT
+          </Heading>
+          <Text size="5" color="gray" style={{ maxWidth: '600px' }}>
+            Bring the power of AI directly to your browser. Get instant assistance, summaries, and insights without interrupting your workflow.
+          </Text>
+
+          <Flex gap="4" wrap="wrap" justify="center" mt="4">
+            <Button size="4" asChild>
+              <Link href="https://chrome.google.com/webstore" target="_blank" rel="noreferrer">
+                Install Extension
+              </Link>
+            </Button>
+            <Button size="4" variant="soft" asChild>
+              <Link href="#features">Learn More</Link>
+            </Button>
+          </Flex>
+        </Flex>
+
+        {/* Screenshot Placeholder */}
+        <Flex justify="center" mb="8" style={{ padding: '0 24px' }}>
+          <Card
+            size="4"
+            variant="surface"
+            style={{
+              width: '100%',
+              maxWidth: '800px',
+              height: '400px',
+              background: 'linear-gradient(135deg, rgba(129, 140, 248, 0.1), transparent 60%), rgba(15, 23, 42, 0.85)',
+            }}
+          >
+            <Flex direction="column" align="center" justify="center" height="100%" gap="4">
+              <Text size="6" weight="bold" color="indigo">
+                SideThreadGPT
+              </Text>
+              <Text size="3" color="gray">
+                Extension Screenshot Placeholder
+              </Text>
+              <Text size="2" color="gray">
+                Shows the extension in action on a real website
+              </Text>
+            </Flex>
+          </Card>
+        </Flex>
+
+        <Separator orientation="horizontal" size="4" />
+
+        {/* Features Section */}
+        <Flex
+          id="features"
+          direction="column"
+          align="center"
+          gap="8"
+          style={{ maxWidth: '1000px', margin: '0 auto', padding: '80px 24px' }}
+        >
+          <Flex direction="column" gap="3" align="center">
+            <Heading size="7" weight="bold">
+              Powerful Features
+            </Heading>
+            <Text size="4" color="gray" align="center" style={{ maxWidth: '600px' }}>
+              Everything you need to enhance your browsing experience with AI assistance.
+            </Text>
+          </Flex>
+
+          <Flex gap="4" wrap="wrap" justify="center" style={{ width: '100%' }}>
+            {features.map((feature) => (
+              <Card
+                key={feature.title}
+                size="3"
+                variant="surface"
+                style={{
+                  width: '300px',
+                  background: 'linear-gradient(135deg, rgba(129, 140, 248, 0.05), transparent 60%), rgba(15, 23, 42, 0.85)',
+                }}
+              >
+                <Flex direction="column" gap="3" align="start">
+                  <Heading as="h3" size="4" weight="bold">
+                    {feature.title}
+                  </Heading>
+                  <Text size="2" color="gray" style={{ lineHeight: '1.5' }}>
+                    {feature.description}
+                  </Text>
+                </Flex>
+              </Card>
+            ))}
+          </Flex>
+        </Flex>
+
+        <Separator orientation="horizontal" size="4" />
+
+        {/* Use Cases Section */}
+        <Flex
+          direction="column"
+          align="center"
+          gap="6"
+          style={{ maxWidth: '800px', margin: '0 auto', padding: '80px 24px' }}
+        >
+          <Flex direction="column" gap="3" align="center">
+            <Heading size="6" weight="bold">
+              What You Can Do
+            </Heading>
+            <Text size="4" color="gray" align="center">
+              Real-world use cases that make your browsing more productive.
+            </Text>
+          </Flex>
+
+          <Card
+            size="4"
+            variant="surface"
+            style={{
+              width: '100%',
+              background: 'linear-gradient(135deg, rgba(129, 140, 248, 0.05), transparent 60%), rgba(15, 23, 42, 0.85)',
+            }}
+          >
+            <Flex direction="column" gap="4">
+              {useCases.map((useCase, index) => (
+                <Flex key={index} align="start" gap="3">
+                  <Badge color="indigo" variant="soft" style={{ marginTop: '2px' }}>
+                    {index + 1}
+                  </Badge>
+                  <Text size="3" style={{ lineHeight: '1.5' }}>
+                    {useCase}
+                  </Text>
+                </Flex>
+              ))}
+            </Flex>
+          </Card>
+        </Flex>
+
+        <Separator orientation="horizontal" size="4" />
+
+        {/* CTA Section */}
+        <Flex
+          direction="column"
+          align="center"
+          gap="6"
+          style={{ maxWidth: '600px', margin: '0 auto', padding: '80px 24px', textAlign: 'center' }}
+        >
+          <Heading size="6" weight="bold">
+            Ready to Enhance Your Browsing?
+          </Heading>
+          <Text size="4" color="gray">
+            Join thousands of users who have already transformed their web experience with SideThreadGPT.
+          </Text>
+
+          <Flex gap="4" wrap="wrap" justify="center">
+            <Button size="4" asChild>
+              <Link href="https://chrome.google.com/webstore" target="_blank" rel="noreferrer">
+                Install from Chrome Web Store
+              </Link>
+            </Button>
+            <Button size="4" variant="soft" asChild>
+              <Link href="/blog/building-sidethreadgpt">Read Our Story</Link>
+            </Button>
+          </Flex>
+
+          <Text size="2" color="gray">
+            Free to install • No account required • Privacy-focused
+          </Text>
+        </Flex>
+      </main>
+    </Box>
+  );
+}

--- a/src/components/Hello.tsx
+++ b/src/components/Hello.tsx
@@ -1,11 +1,11 @@
 import { Heading, Text } from '@radix-ui/themes';
 
-export default function Hello() {
+export default function Hero() {
   return (
     <Heading size="9" weight="bold" align="center">
-      Launch faster with{' '}
+      Productive tools for{' '}
       <Text as="span" color="indigo">
-        Vibe
+        your flow
       </Text>
     </Heading>
   );

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,44 @@
+import { Box, Flex, Heading, Link, Text } from '@radix-ui/themes';
+import NextLink from 'next/link';
+
+export default function Navigation() {
+  return (
+    <Box
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 50,
+        backdropFilter: 'blur(12px)',
+        backgroundColor: 'rgba(9, 9, 11, 0.8)',
+        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+      }}
+    >
+      <Flex
+        justify="between"
+        align="center"
+        style={{
+          maxWidth: '1200px',
+          margin: '0 auto',
+          padding: '16px 24px',
+        }}
+      >
+        <NextLink href="/" style={{ textDecoration: 'none' }}>
+          <Heading size="5" weight="bold">
+            <Text as="span" color="indigo">
+              Toolz
+            </Text>
+          </Heading>
+        </NextLink>
+
+        <Flex gap="6" align="center">
+          <Link asChild>
+            <NextLink href="/">Home</NextLink>
+          </Link>
+          <Link asChild>
+            <NextLink href="/blog">Blog</NextLink>
+          </Link>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/ProductsShowcase.tsx
+++ b/src/components/ProductsShowcase.tsx
@@ -1,0 +1,135 @@
+import {
+  Badge,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Link,
+  Text,
+} from '@radix-ui/themes';
+import NextLink from 'next/link';
+
+interface Product {
+  id: string;
+  name: string;
+  description: string;
+  type: 'Chrome Extension' | 'Web App' | 'Mobile App';
+  status: 'available' | 'coming-soon';
+  href?: string;
+  externalLink?: string;
+}
+
+const products: Product[] = [
+  {
+    id: 'sidethreadgpt',
+    name: 'SideThreadGPT',
+    description: 'AI-powered Chrome extension that brings GPT directly to your browsing experience. Get instant answers and assistance without leaving your current tab.',
+    type: 'Chrome Extension',
+    status: 'available',
+    href: '/products/sidethreadgpt',
+    externalLink: 'https://chrome.google.com/webstore',
+  },
+  {
+    id: 'focusflow',
+    name: 'FocusFlow',
+    description: 'Productivity web app that helps you maintain deep work sessions with smart break reminders and distraction blocking.',
+    type: 'Web App',
+    status: 'coming-soon',
+  },
+  {
+    id: 'taskmaster',
+    name: 'TaskMaster',
+    description: 'Mobile task management app with AI-powered scheduling and priority optimization for maximum productivity.',
+    type: 'Mobile App',
+    status: 'coming-soon',
+  },
+  {
+    id: 'codeassist',
+    name: 'CodeAssist',
+    description: 'Developer productivity extension that provides intelligent code suggestions and automated refactoring tools.',
+    type: 'Chrome Extension',
+    status: 'coming-soon',
+  },
+];
+
+export default function ProductsShowcase() {
+  return (
+    <Flex direction="column" gap="6" align="center" style={{ width: '100%' }}>
+      <Flex direction="column" gap="3" align="center">
+        <Heading size="7" weight="bold">
+          Our Products
+        </Heading>
+        <Text size="4" color="gray" align="center" style={{ maxWidth: '600px' }}>
+          Discover our suite of productivity tools designed to enhance your workflow and boost your efficiency.
+        </Text>
+      </Flex>
+
+      <Flex
+        gap="4"
+        wrap="wrap"
+        justify="center"
+        style={{ width: '100%', maxWidth: '1200px' }}
+      >
+        {products.map((product) => (
+          <Card
+            key={product.id}
+            size="3"
+            variant="surface"
+            style={{
+              width: '320px',
+              minHeight: '240px',
+              cursor: product.status === 'available' ? 'pointer' : 'default',
+              opacity: product.status === 'coming-soon' ? 0.7 : 1,
+              background: product.status === 'available' 
+                ? 'linear-gradient(135deg, rgba(129, 140, 248, 0.1), transparent 60%), rgba(15, 23, 42, 0.85)'
+                : 'rgba(15, 23, 42, 0.5)',
+            }}
+          >
+            <Flex direction="column" gap="3" height="100%">
+              <Flex justify="between" align="start">
+                <Badge
+                  color={product.status === 'available' ? 'green' : 'gray'}
+                  variant="soft"
+                >
+                  {product.status === 'available' ? 'Available' : 'Coming Soon'}
+                </Badge>
+                <Badge variant="outline" size="1">
+                  {product.type}
+                </Badge>
+              </Flex>
+
+              <Flex direction="column" gap="2" style={{ flex: 1 }}>
+                <Heading as="h3" size="5" weight="bold">
+                  {product.name}
+                </Heading>
+                <Text size="2" color="gray" style={{ lineHeight: '1.5' }}>
+                  {product.description}
+                </Text>
+              </Flex>
+
+              <Flex gap="2" mt="auto">
+                {product.status === 'available' && product.href && (
+                  <Button size="2" asChild style={{ flex: 1 }}>
+                    <NextLink href={product.href}>Learn More</NextLink>
+                  </Button>
+                )}
+                {product.status === 'available' && product.externalLink && (
+                  <Button size="2" variant="soft" asChild>
+                    <Link href={product.externalLink} target="_blank" rel="noreferrer">
+                      Install
+                    </Link>
+                  </Button>
+                )}
+                {product.status === 'coming-soon' && (
+                  <Button size="2" variant="soft" disabled style={{ flex: 1 }}>
+                    Coming Soon
+                  </Button>
+                )}
+              </Flex>
+            </Flex>
+          </Card>
+        ))}
+      </Flex>
+    </Flex>
+  );
+}


### PR DESCRIPTION
Transform the template website into a product studio hub for "Toolz" to showcase productive tools, including a home page, blog, and product detail pages, starting with SideThreadGPT.

---
<a href="https://cursor.com/background-agent?bcId=bc-cad10686-059e-4ec0-a393-4f97d2b2d87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cad10686-059e-4ec0-a393-4f97d2b2d87b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

